### PR TITLE
Fix a crash when no concept network is given to propagate()

### DIFF
--- a/packages/state/__tests__/state.js
+++ b/packages/state/__tests__/state.js
@@ -157,6 +157,10 @@ describe('@ector/state', () => {
     });
 
     describe('propagate', () => {
+        it('should not crash when no concept network', () => {
+            expect(CNS.propagate(null, null)).toEqual({});
+        });
+
         it('should deactivate node without afferent links', () => {
             const cn = {
                 node: [{ label: 'a', occ: 1 }, { label: 'b', occ: 1}],

--- a/packages/state/src/state.js
+++ b/packages/state/src/state.js
@@ -147,7 +147,7 @@ export function propagate(cn, cns, options = { decay: 40, memoryPerf: 100 }) {
     const influenceNb = []; // node id -> nb of influence
     /** @type number[] */
     const influenceValue = []; // node id -> influence value
-    cn.node.forEach(node => {
+    cn && cn.node && cn.node.forEach(node => {
         const label = node.label;
         if (!cns0[label]) return; // Only nodes with an activation value
         const old = cns0[label].old;
@@ -184,7 +184,7 @@ export function propagate(cn, cns, options = { decay: 40, memoryPerf: 100 }) {
             return { ...cnst, [label]: { ...state, value } };
         },
         {},
-        cn.node,
+        cn ? cn.node : [],
     );
 
     return cns1;


### PR DESCRIPTION
When no concept network is given to [`propagate()`](https://github.com/parmentf/ector-monorepo/blob/master/packages/state/src/state.js#L150), the function crashed.
Let's make it return an empty concept network.

This should close issue #5